### PR TITLE
Scenario: internal deps change

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -1,0 +1,11 @@
+# The project view file (.bazelproject) is used to import targets into the IDE.
+#
+# See: https://ij.bazel.build/docs/project-views.html
+#
+# This files provides a default experience for developers working with the project.
+# You should customize it to suite your needs.
+
+directories:
+  .
+
+derive_targets_from_directories: true

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
 common --announce_rc
+common --nojava_header_compilation
 common --experimental_java_classpath=bazel
 common --experimental_strict_java_deps=error
+

--- a/.eclipse/.bazelproject
+++ b/.eclipse/.bazelproject
@@ -1,0 +1,1 @@
+import .bazelproject

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bazel-*
 /disk_cache
+*.log

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/lib/A2.java
+++ b/lib/A2.java
@@ -1,11 +1,11 @@
 package lib;
 
-public class A {
+public class A2 {
   public static String getPublic() {
     return getPrivate();
   }
 
   private static String getPrivate() {
-    return A3.getPublic();
+    return "Hello from A2!";
   }
 }

--- a/lib/A3.java
+++ b/lib/A3.java
@@ -1,11 +1,11 @@
 package lib;
 
-public class A {
+public class A3 {
   public static String getPublic() {
     return getPrivate();
   }
 
   private static String getPrivate() {
-    return A3.getPublic();
+    return "Hello from A3!";
   }
 }

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -1,6 +1,16 @@
 java_library(
     name = "A",
     srcs = ["A.java"],
+    deps = ["A2", "A3"],
     visibility = ["//visibility:public"],
 )
 
+java_library(
+    name = "A2",
+    srcs = ["A2.java"],
+)
+
+java_library(
+    name = "A3",
+    srcs = ["A3.java"],
+)

--- a/patches/internal-deps-change.patch
+++ b/patches/internal-deps-change.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/A.java b/lib/A.java
+index b350a94..07ff48e 100644
+--- a/lib/A.java
++++ b/lib/A.java
+@@ -6,6 +6,6 @@ public class A {
+   }
+ 
+   private static String getPrivate() {
+-    return A3.getPublic();
++    return A2.getPublic();
+   }
+ }

--- a/script.sh
+++ b/script.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-git checkout -- *.java
+git reset --hard
 
 rm -rf disk_cache
 "${BAZEL:-bazel}" --nohome_rc --nosystem_rc clean --expunge
@@ -14,7 +14,9 @@ time=$(date +%s%3N)
 
 echo "=================================================="
 echo "Modify the implementation of a private method in A"
-echo "Only rebuilds A                                   "
+echo "to use another dependency                         "
+echo "                                                  "
+echo "expected: Rebuild only A                          "
 echo "=================================================="
-sed -i -e "s/Hello from A\![0-9]*/Hello from A\!$(date +%s%3N)/g" lib/A.java
-#"${BAZEL:-bazel}" --nohome_rc --nosystem_rc run //:main --disk_cache=$(pwd)/disk_cache --verbose_explanations --explain=explain-Apriv1.txt "$@"
+git apply patches/internal-deps-change.patch
+"${BAZEL:-bazel}" --nohome_rc --nosystem_rc run //:main --disk_cache=$(pwd)/disk_cache --verbose_explanations --explain=patches/internal-deps-change.explain.log "$@"

--- a/script.sh
+++ b/script.sh
@@ -12,11 +12,20 @@ rm -rf disk_cache
 
 time=$(date +%s%3N)
 
+run_bazel_with_patch()
+{
+  PATCH_FILE=$1
+  shift;
+  git apply "patches/$PATCH_FILE.patch"
+  "${BAZEL:-bazel}" --nohome_rc --nosystem_rc run //:main --disk_cache=$(pwd)/disk_cache --verbose_explanations --explain=patches/$PATCH_FILE.explain.log "$@"
+  git reset --hard
+}
+
+
 echo "=================================================="
 echo "Modify the implementation of a private method in A"
 echo "to use another dependency                         "
 echo "                                                  "
 echo "expected: Rebuild only A                          "
 echo "=================================================="
-git apply patches/internal-deps-change.patch
-"${BAZEL:-bazel}" --nohome_rc --nosystem_rc run //:main --disk_cache=$(pwd)/disk_cache --verbose_explanations --explain=patches/internal-deps-change.explain.log "$@"
+run_bazel_with_patch internal-deps-change "$@"

--- a/script.sh
+++ b/script.sh
@@ -17,37 +17,4 @@ echo "Modify the implementation of a private method in A"
 echo "Only rebuilds A                                   "
 echo "=================================================="
 sed -i -e "s/Hello from A\![0-9]*/Hello from A\!$(date +%s%3N)/g" lib/A.java
-"${BAZEL:-bazel}" --nohome_rc --nosystem_rc run //:main --disk_cache=$(pwd)/disk_cache "$@"
-
-echo "============================================="
-echo "Modify the signature of a private method in A"
-echo "Only rebuilds A                              "
-echo "============================================="
-sed -i -e "s/getPrivate/getPrivate$(date +%s%3N)/g" lib/A.java
-"${BAZEL:-bazel}" --nohome_rc --nosystem_rc run //:main --disk_cache=$(pwd)/disk_cache "$@"
-
-echo "=============================================================="
-echo "Modify the signature of a public method in A                  "
-echo "Only rebuilds A and B with --experimental_java_classpath=bazel"
-echo "Otherwise rebuilds A, B, and C                                "
-echo "=============================================================="
-suffix=$(date +%s%3N)
-sed -i -e "s/getPublic/getPublic${suffix}/g" lib/A.java
-sed -i -e "s/lib\\.A\\.getPublic/lib\\.A\\.getPublic${suffix}/g" B.java
-"${BAZEL:-bazel}" --nohome_rc --nosystem_rc run //:main --disk_cache=$(pwd)/disk_cache "$@"
-
-echo "================================="
-echo "Make the direct dep A of B unused"
-echo "Only rebuilds B                  "
-echo "================================="
-sed -i -e "s/lib\\.A\\.getPublic[0-9]*()/\"Inlined Hello from A\"/g" B.java
-"${BAZEL:-bazel}" --nohome_rc --nosystem_rc run //:main --disk_cache=$(pwd)/disk_cache "$@"
-
-echo "================================================================="
-echo "Modify the signature of a public method in the (now unused) dep A"
-echo "Only rebuilds A and B with --experimental_java_classpath=bazel   "
-echo "Otherwise rebuilds A, B, and C                                   "
-echo "Would ideally only rebuild A since A wasn't used to compile B    "
-echo "================================================================="
-sed -i -e "s/getPublic[0-9]*/getPublic$(date +%s%3N)/g" lib/A.java
-"${BAZEL:-bazel}" --nohome_rc --nosystem_rc run //:main --disk_cache=$(pwd)/disk_cache "$@"
+#"${BAZEL:-bazel}" --nohome_rc --nosystem_rc run //:main --disk_cache=$(pwd)/disk_cache --verbose_explanations --explain=explain-Apriv1.txt "$@"


### PR DESCRIPTION
Rewrote the script a little bit to apply patches instead of `sed`.

Here is what I see for `patches/internal-deps-change.patch`:
```
Executing action 'Building lib/libA.jar (1 source file)': One of the files has changed.
Executing action 'Extracting interface for jar bazel-out/darwin_x86_64-fastbuild/bin/lib/libA.jar': One of the files has changed.
Executing action 'Building libB.jar (1 source file)': One of the files has changed.
```

Bazel says:
```
4 processes: 1 disk cache hit, 1 internal, 1 darwin-sandbox, 1 worker.
```

Is `libB.jar` the disk cache hit?